### PR TITLE
Add test to check if a data split is stratified

### DIFF
--- a/tests/test_mcs_kfold.py
+++ b/tests/test_mcs_kfold.py
@@ -1,6 +1,7 @@
 import pandas as pd
 import pytest
-
+import numpy as np
+import numpy.testing as npt
 from mcs_kfold import MCSKFold
 
 SEED = 2020
@@ -35,6 +36,32 @@ def test_split(num_cv, shuffle_mc):
     mcskf = MCSKFold(n_splits=num_cv, max_iter=1, shuffle_mc=shuffle_mc, global_seed=SEED)
     indices = mcskf.split(df=df, target_cols=["Survived", "Pclass", "Sex"])
     assert isinstance(indices, list)
+
+
+@pytest.mark.parametrize("num_cv, shuffle_mc", make_param_split())
+def test_stratified_split(num_cv, shuffle_mc):
+    target_cols = ["Survived", "Pclass", "Sex"]
+    df = pd.read_csv("tests/test_data/train_titanic.csv")
+    mcskf = MCSKFold(n_splits=num_cv, max_iter=1, shuffle_mc=shuffle_mc,
+                     global_seed=SEED)
+    indices = mcskf.split(df=df, target_cols=target_cols)
+
+    tr_ = {col: np.zeros((len(indices), len(df[col].unique())))
+           for col in target_cols}
+    val_ = {col: np.zeros((len(indices), len(df[col].unique())))
+           for col in target_cols}
+    for fold, (train_index, valid_index) in enumerate(indices):
+        for col in target_cols:
+            tr_[col][fold] = df.iloc[train_index][col].value_counts(
+                normalize=True)
+            val_[col][fold] = df.iloc[valid_index][col].value_counts(
+                normalize=True)
+    assert_threshold = 0.1
+    for col in target_cols:
+        tr_std_per_label = tr_[col].std(axis=0)
+        val_std_per_label = val_[col].std(axis=0)
+        npt.assert_array_less(tr_std_per_label, assert_threshold)
+        npt.assert_array_less(val_std_per_label, assert_threshold)
 
 
 if __name__ == "__main__":

--- a/tests/test_mcs_kfold.py
+++ b/tests/test_mcs_kfold.py
@@ -42,20 +42,15 @@ def test_split(num_cv, shuffle_mc):
 def test_stratified_split(num_cv, shuffle_mc):
     target_cols = ["Survived", "Pclass", "Sex"]
     df = pd.read_csv("tests/test_data/train_titanic.csv")
-    mcskf = MCSKFold(n_splits=num_cv, max_iter=1, shuffle_mc=shuffle_mc,
-                     global_seed=SEED)
+    mcskf = MCSKFold(n_splits=num_cv, max_iter=1, shuffle_mc=shuffle_mc, global_seed=SEED)
     indices = mcskf.split(df=df, target_cols=target_cols)
 
-    tr_ = {col: np.zeros((len(indices), len(df[col].unique())))
-           for col in target_cols}
-    val_ = {col: np.zeros((len(indices), len(df[col].unique())))
-           for col in target_cols}
+    tr_ = {col: np.zeros((len(indices), len(df[col].unique()))) for col in target_cols}
+    val_ = {col: np.zeros((len(indices), len(df[col].unique()))) for col in target_cols}
     for fold, (train_index, valid_index) in enumerate(indices):
         for col in target_cols:
-            tr_[col][fold] = df.iloc[train_index][col].value_counts(
-                normalize=True)
-            val_[col][fold] = df.iloc[valid_index][col].value_counts(
-                normalize=True)
+            tr_[col][fold] = df.iloc[train_index][col].value_counts(normalize=True)
+            val_[col][fold] = df.iloc[valid_index][col].value_counts(normalize=True)
     assert_threshold = 0.1
     for col in target_cols:
         tr_std_per_label = tr_[col].std(axis=0)

--- a/tests/test_mcs_kfold.py
+++ b/tests/test_mcs_kfold.py
@@ -1,7 +1,8 @@
-import pandas as pd
-import pytest
 import numpy as np
 import numpy.testing as npt
+import pandas as pd
+import pytest
+
 from mcs_kfold import MCSKFold
 
 SEED = 2020


### PR DESCRIPTION
[test_mcs_kfold.py](https://github.com/MasashiSode/mcs_kfold/blob/master/tests/test_mcs_kfold.py) didn't have a test code to verify that the way the data is divided is stratified, so we created one.
Currently, if the standard deviation of each label is less than 0.1, it is an error.