### PR TITLE
Add GitHub_Actions

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -30,7 +30,7 @@ jobs:
       run: poetry run pytest
 
     - name: Test with black
-      run: poetry run black --check .
+      run: poetry run black mcs_kfold/ --check --line-length 99
 
     - name: Test with isort
       run: poetry run isort -c

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -1,0 +1,30 @@
+name: Python package
+
+on: [push]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: [3.6, 3.7, 3.8]
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v1
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Install Poetry
+      run: |
+        python -m pip install --upgrade pip setuptools poetry
+
+    - name: Install dependencies
+      run: |
+        poetry run pip install -U pip
+        poetry update
+        poetry install
+
+    - name: Run pytest
+      run: poetry run pytest

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -27,4 +27,10 @@ jobs:
         poetry install
 
     - name: Run pytest
-      run: poetry run pytest
+      run: pytest
+
+    - name: Test with black
+      run: black --check .
+
+    - name: Test with isort
+      run: isort -c

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -27,10 +27,10 @@ jobs:
         poetry install
 
     - name: Run pytest
-      run: pytest
+      run: poetry run pytest
 
     - name: Test with black
-      run: black --check .
+      run: poetry run black --check .
 
     - name: Test with isort
-      run: isort -c
+      run: poetry runv isort -c

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -33,4 +33,4 @@ jobs:
       run: poetry run black --check .
 
     - name: Test with isort
-      run: poetry runv isort -c
+      run: poetry run isort -c


### PR DESCRIPTION
for Python version 3.6/3.7/3.8
- pytest
- black
- isort

And I checked the repository of the fork destination.
https://github.com/wakamezake/mcs_kfold/actions/runs/235876068